### PR TITLE
add advertiserDomain to bid object

### DIFF
--- a/modules/pxyzBidAdapter.js
+++ b/modules/pxyzBidAdapter.js
@@ -133,6 +133,7 @@ export const spec = {
 }
 
 function newBid(bid, currency) {
+  const { adomain } = bid;
   return {
     requestId: bid.impid,
     mediaType: BANNER,
@@ -144,6 +145,9 @@ function newBid(bid, currency) {
     ttl: 300,
     netRevenue: true,
     currency: currency,
+    meta: {
+      ...(adomain && adomain.length > 0 ? { advertiserDomains: adomain } : {})
+    }
   };
 }
 

--- a/test/spec/modules/pxyzBidAdapter_spec.js
+++ b/test/spec/modules/pxyzBidAdapter_spec.js
@@ -191,11 +191,15 @@ describe('pxyzBidAdapter', function () {
           'mediaType': 'banner',
           'currency': 'AUD',
           'ttl': 300,
-          'netRevenue': true
+          'netRevenue': true,
+          'meta': {
+            advertiserDomains: ['pg.xyz']
+          }
         }
       ];
       let result = spec.interpretResponse({ body: response }, {bidderRequest});
       expect(Object.keys(result[0])).to.have.members(Object.keys(expectedResponse[0]));
+      expect(result[0].meta.advertiserDomains).to.deep.equal(expectedResponse[0].meta.advertiserDomains);
     });
 
     it('handles nobid response', function () {


### PR DESCRIPTION
<!--
Thank you for your pull request. Please make sure this PR is scoped to one change, and that any added or changed code includes tests with greater than 80% code coverage. See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.
-->

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [ ] Bugfix
- [ ] Feature
- [ ] New bidder adapter  <!--  IMPORTANT: if checking here, also submit your bidder params documentation here https://github.com/prebid/prebid.github.io/tree/master/dev-docs/bidders --> 
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Does this change affect user-facing APIs or examples documented on http://prebid.org?
- [ ] Other

## Description of change
<!-- Describe the change proposed in this pull request -->

<!-- For new bidder adapters, please provide the following -->
- test parameters for validating bids
```
{
  bidder: '<bidder name>',
  params: {
    // ...
  }
}
```

Be sure to test the integration with your adserver using the [Hello World](/integrationExamples/gpt/hello_world.html) sample page.

- contact email of the adapter’s maintainer
- [ ] official adapter submission

For any changes that affect user-facing APIs or example code documented on http://prebid.org, please provide:

- A link to a PR on the docs repo at https://github.com/prebid/prebid.github.io/

## Other information
<!-- References to related PR or issue #s, @mentions of the person or team responsible for reviewing changes, etc. -->
